### PR TITLE
feat: persist js-dos key in user settings

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir $APP_NAME
           shopt -s extglob
-          cp -r !($APP_NAME|.git*|.|..|composer.json|package.json|.php-cs-fixer.dist.php) $APP_NAME
+          cp -r !($APP_NAME|.git*|.|..|composer.json|package.json|.php-cs-fixer.dist.php|tests) $APP_NAME
           tar -zcvf $APP_NAME.tar.gz $APP_NAME
         shell: bash
       - name: Create the release

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 
 /.php-cs-fixer.cache
 /tests/.phpunit.cache
+/build/
 
 /node_modules/

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,6 +20,10 @@
 	<dependencies>
 		<nextcloud min-version="30" max-version="33"/>
 	</dependencies>
+	<settings>
+		<personal>OCA\Doom\Settings\PersonalSettings</personal>
+		<personal-section>OCA\Doom\Settings\PersonalSection</personal-section>
+	</settings>
 	<navigations>
 		<navigation>
 			<id>doom_nextcloud</id>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -7,5 +7,8 @@ return [
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'api#getDoomBundle', 'url' => '/bundle/doom.jsdos', 'verb' => 'GET'],
 		['name' => 'api#getEmulatorFile', 'url' => '/emulators/{filename}', 'verb' => 'GET'],
+		['name' => 'api#getState', 'url' => '/jsdos-state', 'verb' => 'GET'],
+		['name' => 'api#setKey', 'url' => '/jsdos-key', 'verb' => 'PUT'],
+		['name' => 'api#deleteState', 'url' => '/jsdos-state', 'verb' => 'DELETE'],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -7,7 +7,6 @@ return [
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'api#getDoomBundle', 'url' => '/bundle/doom.jsdos', 'verb' => 'GET'],
 		['name' => 'api#getEmulatorFile', 'url' => '/emulators/{filename}', 'verb' => 'GET'],
-		['name' => 'api#getState', 'url' => '/jsdos-state', 'verb' => 'GET'],
 		['name' => 'api#setKey', 'url' => '/jsdos-key', 'verb' => 'PUT'],
 		['name' => 'api#deleteState', 'url' => '/jsdos-state', 'verb' => 'DELETE'],
 	],

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
 	"name": "nextcloud/doom_nextcloud",
-	"description": "Allows to play Doom on NextCloud.
-
-Doom is one of the most influential games in video game history. Created by id Software, it popularized the first-person shooter (FPS) genre by placing the player in the role of a space marine fighting demons and hellish creatures inside futuristic bases on Mars",
+	"description": "Allows to play Doom on NextCloud. Doom is one of the most influential games in video game history. Created by id Software, it popularized the first-person shooter (FPS) genre by placing the player in the role of a space marine fighting demons and hellish creatures inside futuristic bases on Mars",
 	"license": "AGPL-3.0-or-later",
 	"authors": [
 		{
@@ -27,7 +25,8 @@ Doom is one of the most influential games in video game history. Created by id S
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"psalm": "psalm --threads=1 --no-cache",
-		"test:unit": "phpunit tests -c tests/phpunit.xml --colors=always --fail-on-warning --fail-on-risky",
+		"test:unit": "vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --colors=always --fail-on-warning --fail-on-risky",
+		"test:coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit -c tests/php/phpunit.xml",
 		"openapi": "generate-spec",
 		"rector": "rector && composer cs:fix"
 	},
@@ -37,6 +36,7 @@ Doom is one of the most influential games in video game history. Created by id S
 	},
 	"require-dev": {
 		"nextcloud/ocp": "dev-stable30",
+		"phpunit/phpunit": "^10.5",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {

--- a/css/doom.css
+++ b/css/doom.css
@@ -1,0 +1,40 @@
+.doom-wrapper {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+#doom-key-banner {
+	display: none;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 12px;
+	font-size: 0.9em;
+	background-color: var(--color-background-hover);
+	border-bottom: 1px solid var(--color-border);
+}
+
+#doom-key-banner .doom-key-banner-text {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#doom-key-banner a {
+	text-decoration: underline;
+}
+
+#doom-key-banner-dismiss {
+	background: transparent;
+	border: none;
+	padding: 0 4px;
+	font-size: 1.1em;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+}
+
+#doom {
+	width: 100%;
+}

--- a/css/personal-settings.css
+++ b/css/personal-settings.css
@@ -1,0 +1,25 @@
+#doom-personal-settings .doom-key-identity {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
+}
+
+#doom-personal-settings .doom-key-check {
+	color: var(--color-success);
+	font-size: 1.2em;
+}
+
+#doom-personal-settings .doom-key-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 12px;
+	flex-wrap: wrap;
+}
+
+#doom-personal-settings .doom-key-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}

--- a/js/inject-account.js
+++ b/js/inject-account.js
@@ -1,0 +1,15 @@
+(function () {
+    'use strict'
+
+    // Runs BEFORE js-dos.js: js-dos reads its account from this prefixed
+    // localStorage key at script-eval time, so the account (provided by the
+    // server as initial state) must already be there when js-dos loads.
+    try {
+        var account = OCP.InitialState.loadState('doom_nextcloud', 'account')
+        if (account && account.email) {
+            localStorage.setItem('jsdos.8.cached.jsdos.account', JSON.stringify(account))
+        }
+    } catch (e) {
+        // No account or initial state: js-dos simply starts logged out.
+    }
+})()

--- a/js/inject-account.js
+++ b/js/inject-account.js
@@ -13,6 +13,7 @@
             localStorage.removeItem('jsdos.8.cached.jsdos.account')
         }
     } catch (e) {
-        // No initial state: leave localStorage untouched.
+        // Missing or invalid state must never preserve another user's account.
+        localStorage.removeItem('jsdos.8.cached.jsdos.account')
     }
 })()

--- a/js/inject-account.js
+++ b/js/inject-account.js
@@ -8,8 +8,11 @@
         var account = OCP.InitialState.loadState('doom_nextcloud', 'account')
         if (account && account.email) {
             localStorage.setItem('jsdos.8.cached.jsdos.account', JSON.stringify(account))
+        } else {
+            // Key was removed on the server: clear the cached sign-in too.
+            localStorage.removeItem('jsdos.8.cached.jsdos.account')
         }
     } catch (e) {
-        // No account or initial state: js-dos simply starts logged out.
+        // No initial state: leave localStorage untouched.
     }
 })()

--- a/js/load-game.js
+++ b/js/load-game.js
@@ -6,10 +6,6 @@
 
     var banner = document.getElementById('doom-key-banner')
     if (banner) {
-        var settingsLink = document.getElementById('doom-key-banner-settings')
-        if (settingsLink) {
-            settingsLink.href = OC.generateUrl('/settings/user/' + APP_ID)
-        }
         var dismissed = false
         try {
             dismissed = localStorage.getItem(BANNER_DISMISS_KEY) === '1'

--- a/js/load-game.js
+++ b/js/load-game.js
@@ -2,6 +2,33 @@
     'use strict'
 
     var APP_ID = 'doom_nextcloud'
+    var BANNER_DISMISS_KEY = APP_ID + '.keyBannerDismissed'
+
+    var banner = document.getElementById('doom-key-banner')
+    if (banner) {
+        var settingsLink = document.getElementById('doom-key-banner-settings')
+        if (settingsLink) {
+            settingsLink.href = OC.generateUrl('/settings/user/' + APP_ID)
+        }
+        var dismissed = false
+        try {
+            dismissed = localStorage.getItem(BANNER_DISMISS_KEY) === '1'
+        } catch (e) {
+        }
+        if (!dismissed) {
+            banner.style.display = 'flex'
+        }
+        var dismissButton = document.getElementById('doom-key-banner-dismiss')
+        if (dismissButton) {
+            dismissButton.addEventListener('click', function () {
+                try {
+                    localStorage.setItem(BANNER_DISMISS_KEY, '1')
+                } catch (e) {
+                }
+                banner.style.display = 'none'
+            })
+        }
+    }
 
     // The account was already injected into localStorage by inject-account.js
     // (before js-dos loaded), so we only need to boot the emulator here.

--- a/js/load-game.js
+++ b/js/load-game.js
@@ -1,4 +1,12 @@
-Dos(document.getElementById("doom"), {
-    url: OC.generateUrl('/apps/doom_nextcloud/bundle/doom.jsdos'),
-    pathPrefix: (OC.webroot || '') + '/index.php/apps/doom_nextcloud/emulators/',
-});
+(function () {
+    'use strict'
+
+    var APP_ID = 'doom_nextcloud'
+
+    // The account was already injected into localStorage by inject-account.js
+    // (before js-dos loaded), so we only need to boot the emulator here.
+    Dos(document.getElementById('doom'), {
+        url: OC.generateUrl('/apps/' + APP_ID + '/bundle/doom.jsdos'),
+        pathPrefix: (OC.webroot || '') + '/index.php/apps/' + APP_ID + '/emulators/',
+    })
+})()

--- a/js/personal-settings.js
+++ b/js/personal-settings.js
@@ -5,6 +5,8 @@
     var KEY_URL = OC.generateUrl('/apps/' + APP_ID + '/jsdos-key')
     var STATE_URL = OC.generateUrl('/apps/' + APP_ID + '/jsdos-state')
 
+    var currentEmail = null
+
     function el(id) {
         return document.getElementById(id)
     }
@@ -27,8 +29,31 @@
         }
     }
 
-    function signedIn(email) {
-        setStatus(t(APP_ID, 'Signed in as {email}', { email: email }), true)
+    function showSignedIn(email) {
+        currentEmail = email || currentEmail
+        var emailEl = el('doom-key-email')
+        if (emailEl) {
+            emailEl.textContent = currentEmail || ''
+        }
+        el('doom-key-signed-in').style.display = ''
+        el('doom-key-form').style.display = 'none'
+        var input = el('doom-key-input')
+        if (input) {
+            input.value = ''
+        }
+    }
+
+    function showForm() {
+        el('doom-key-signed-in').style.display = 'none'
+        el('doom-key-form').style.display = ''
+        var cancel = el('doom-key-cancel')
+        if (cancel) {
+            cancel.style.display = currentEmail ? '' : 'none'
+        }
+        var input = el('doom-key-input')
+        if (input) {
+            input.focus()
+        }
     }
 
     function save() {
@@ -45,8 +70,8 @@
         }).then(function (response) {
             if (response.ok) {
                 return response.json().then(function (data) {
-                    input.value = ''
-                    signedIn(data.account && data.account.email)
+                    showSignedIn(data.account && data.account.email)
+                    setStatus(t(APP_ID, 'Key validated and saved.'), true)
                 })
             }
             if (response.status === 422) {
@@ -62,18 +87,26 @@
     function forget() {
         fetch(STATE_URL, { method: 'DELETE', headers: headers() })
             .then(function (response) {
-                setStatus(
-                    response.ok ? t(APP_ID, 'Key removed.') : t(APP_ID, 'Could not remove the key.'),
-                    response.ok
-                )
+                if (response.ok) {
+                    currentEmail = null
+                    showForm()
+                    setStatus(t(APP_ID, 'Key removed.'), true)
+                } else {
+                    setStatus(t(APP_ID, 'Could not remove the key.'), false)
+                }
             }).catch(function () {
                 setStatus(t(APP_ID, 'Could not remove the key.'), false)
             })
     }
 
     function init() {
+        var signedInBlock = el('doom-key-signed-in')
+        currentEmail = (signedInBlock && signedInBlock.getAttribute('data-email')) || null
+
         var saveButton = el('doom-key-save')
         var forgetButton = el('doom-key-forget')
+        var changeButton = el('doom-key-change')
+        var cancelButton = el('doom-key-cancel')
         var input = el('doom-key-input')
         if (saveButton) {
             saveButton.addEventListener('click', save)
@@ -81,17 +114,24 @@
         if (forgetButton) {
             forgetButton.addEventListener('click', forget)
         }
+        if (changeButton) {
+            changeButton.addEventListener('click', function () {
+                setStatus('', true)
+                showForm()
+            })
+        }
+        if (cancelButton) {
+            cancelButton.addEventListener('click', function () {
+                setStatus('', true)
+                showSignedIn(currentEmail)
+            })
+        }
         if (input) {
             input.addEventListener('keydown', function (event) {
                 if (event.key === 'Enter') {
                     save()
                 }
             })
-        }
-        var status = el('doom-key-status')
-        var email = status && status.getAttribute('data-email')
-        if (email) {
-            signedIn(email)
         }
     }
 

--- a/js/personal-settings.js
+++ b/js/personal-settings.js
@@ -76,6 +76,8 @@
             }
             if (response.status === 422) {
                 setStatus(t(APP_ID, 'Invalid key.'), false)
+            } else if (response.status === 503) {
+                setStatus(t(APP_ID, 'Could not reach js-dos. Please try again later.'), false)
             } else {
                 setStatus(t(APP_ID, 'Could not save the key.'), false)
             }

--- a/js/personal-settings.js
+++ b/js/personal-settings.js
@@ -1,0 +1,103 @@
+(function () {
+    'use strict'
+
+    var APP_ID = 'doom_nextcloud'
+    var KEY_URL = OC.generateUrl('/apps/' + APP_ID + '/jsdos-key')
+    var STATE_URL = OC.generateUrl('/apps/' + APP_ID + '/jsdos-state')
+
+    function el(id) {
+        return document.getElementById(id)
+    }
+
+    function headers(extra) {
+        var base = { requesttoken: OC.requestToken, Accept: 'application/json' }
+        if (extra) {
+            Object.keys(extra).forEach(function (key) {
+                base[key] = extra[key]
+            })
+        }
+        return base
+    }
+
+    function setStatus(message, ok) {
+        var status = el('doom-key-status')
+        if (status) {
+            status.textContent = message
+            status.style.color = ok ? 'var(--color-success)' : 'var(--color-error)'
+        }
+    }
+
+    function signedIn(email) {
+        setStatus(t(APP_ID, 'Signed in as {email}', { email: email }), true)
+    }
+
+    function save() {
+        var input = el('doom-key-input')
+        var key = (input.value || '').trim()
+        if (!key) {
+            return
+        }
+        setStatus(t(APP_ID, 'Validating…'), true)
+        fetch(KEY_URL, {
+            method: 'PUT',
+            headers: headers({ 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ key: key }),
+        }).then(function (response) {
+            if (response.ok) {
+                return response.json().then(function (data) {
+                    input.value = ''
+                    signedIn(data.account && data.account.email)
+                })
+            }
+            if (response.status === 422) {
+                setStatus(t(APP_ID, 'Invalid key.'), false)
+            } else {
+                setStatus(t(APP_ID, 'Could not save the key.'), false)
+            }
+        }).catch(function () {
+            setStatus(t(APP_ID, 'Could not save the key.'), false)
+        })
+    }
+
+    function forget() {
+        fetch(STATE_URL, { method: 'DELETE', headers: headers() })
+            .then(function (response) {
+                setStatus(
+                    response.ok ? t(APP_ID, 'Key removed.') : t(APP_ID, 'Could not remove the key.'),
+                    response.ok
+                )
+            }).catch(function () {
+                setStatus(t(APP_ID, 'Could not remove the key.'), false)
+            })
+    }
+
+    function init() {
+        var saveButton = el('doom-key-save')
+        var forgetButton = el('doom-key-forget')
+        var input = el('doom-key-input')
+        if (saveButton) {
+            saveButton.addEventListener('click', save)
+        }
+        if (forgetButton) {
+            forgetButton.addEventListener('click', forget)
+        }
+        if (input) {
+            input.addEventListener('keydown', function (event) {
+                if (event.key === 'Enter') {
+                    save()
+                }
+            })
+        }
+        var status = el('doom-key-status')
+        var email = status && status.getAttribute('data-email')
+        if (email) {
+            signedIn(email)
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+    } else {
+        init()
+    }
+})()

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace OCA\Doom\AppInfo;
 
+use OCA\Doom\Listener\UserDeletedListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserDeletedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'doom_nextcloud';
@@ -18,6 +20,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -7,10 +7,12 @@ namespace OCA\Doom\Controller;
 use OCA\Doom\AppInfo\Application;
 use OCA\Doom\Service\JsDosAccountService;
 use OCA\Doom\Service\JsDosClient;
+use OCA\Doom\Service\JsDosUnavailableException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
@@ -33,32 +35,22 @@ class ApiController extends Controller
 	}
 
 	/**
-	 * Return the stored js-dos account for the current user (null if none).
-	 */
-	#[NoAdminRequired]
-	public function getState(): DataResponse
-	{
-		if ($this->userId === null) {
-			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
-		}
-
-		return new DataResponse([
-			'account' => $this->accountService->get($this->userId),
-		]);
-	}
-
-	/**
 	 * Validate a js-dos key server-side (self-hosted emulators cannot, due to
 	 * CORS), then store and return the resolved account.
 	 */
 	#[NoAdminRequired]
+	#[UserRateLimit(limit: 5, period: 60)]
 	public function setKey(string $key = ''): DataResponse
 	{
 		if ($this->userId === null) {
 			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
-		$account = $this->jsDosClient->resolveAccount($key);
+		try {
+			$account = $this->jsDosClient->resolveAccount($key);
+		} catch (JsDosUnavailableException) {
+			return new DataResponse(['status' => 'unavailable'], Http::STATUS_SERVICE_UNAVAILABLE);
+		}
 		if ($account === null) {
 			return new DataResponse(['status' => 'invalid'], Http::STATUS_UNPROCESSABLE_ENTITY);
 		}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -5,19 +5,84 @@ declare(strict_types=1);
 namespace OCA\Doom\Controller;
 
 use OCA\Doom\AppInfo\Application;
+use OCA\Doom\Service\JsDosAccountService;
+use OCA\Doom\Service\JsDosClient;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\StreamResponse;
+use OCP\IRequest;
 
 /**
  * @psalm-suppress UnusedClass
  */
 class ApiController extends Controller
 {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ?string $userId,
+		private JsDosAccountService $accountService,
+		private JsDosClient $jsDosClient,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Return the stored js-dos account for the current user (null if none).
+	 */
+	#[NoAdminRequired]
+	public function getState(): DataResponse
+	{
+		if ($this->userId === null) {
+			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
+		}
+
+		return new DataResponse([
+			'account' => $this->accountService->get($this->userId),
+		]);
+	}
+
+	/**
+	 * Validate a js-dos key server-side (self-hosted emulators cannot, due to
+	 * CORS), then store and return the resolved account.
+	 */
+	#[NoAdminRequired]
+	public function setKey(string $key = ''): DataResponse
+	{
+		if ($this->userId === null) {
+			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$account = $this->jsDosClient->resolveAccount($key);
+		if ($account === null) {
+			return new DataResponse(['status' => 'invalid'], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+
+		$this->accountService->set($this->userId, $account);
+
+		return new DataResponse(['account' => $account]);
+	}
+
+	/**
+	 * Delete the stored js-dos account for the current user.
+	 */
+	#[NoAdminRequired]
+	public function deleteState(): DataResponse
+	{
+		if ($this->userId === null) {
+			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$this->accountService->delete($this->userId);
+
+		return new DataResponse(['status' => 'ok']);
+	}
+
 	/**
 	 * Serve the doom.jsdos bundle file
 	 *

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -40,7 +40,7 @@ class PageController extends Controller
 		// Expose the stored account so it can be written to localStorage before
 		// js-dos boots (js-dos reads its account at script-eval time).
 		$account = $this->userId !== null ? $this->accountService->get($this->userId) : null;
-		$this->initialState->provideInitialState('account', $account);
+		$this->initialState->provideInitialState('account', $account ?? []);
 
 		$response = new TemplateResponse(
 			Application::APP_ID,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -14,43 +14,51 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 
 /**
  * @psalm-suppress UnusedClass
  */
 class PageController extends Controller
 {
-    public function __construct(
-        string $appName,
-        IRequest $request,
-        private ?string $userId,
-        private JsDosAccountService $accountService,
-        private IInitialState $initialState,
-    ) {
-        parent::__construct($appName, $request);
-    }
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ?string $userId,
+		private JsDosAccountService $accountService,
+		private IInitialState $initialState,
+		private IURLGenerator $urlGenerator,
+	) {
+		parent::__construct($appName, $request);
+	}
 
-    #[NoCSRFRequired]
-    #[NoAdminRequired]
-    #[OpenAPI(OpenAPI::SCOPE_IGNORE)]
-    public function index(): TemplateResponse
-    {
-        // Expose the stored account so it can be written to localStorage before
-        // js-dos boots (js-dos reads its account at script-eval time).
-        $account = $this->userId !== null ? $this->accountService->get($this->userId) : null;
-        $this->initialState->provideInitialState('account', $account);
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
+	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
+	public function index(): TemplateResponse
+	{
+		// Expose the stored account so it can be written to localStorage before
+		// js-dos boots (js-dos reads its account at script-eval time).
+		$account = $this->userId !== null ? $this->accountService->get($this->userId) : null;
+		$this->initialState->provideInitialState('account', $account);
 
-        $response = new TemplateResponse(
-            Application::APP_ID,
-            'index',
-            ['email' => $account['email'] ?? null],
-        );
-        $csp = new ContentSecurityPolicy();
-        $csp->addAllowedScriptDomain('blob:');
-        $csp->addAllowedWorkerSrcDomain('blob:');
-        $csp->allowEvalWasm();
-        $csp->allowEvalScript();
-        $response->setContentSecurityPolicy($csp);
-        return $response;
-    }
+		$response = new TemplateResponse(
+			Application::APP_ID,
+			'index',
+			[
+				'email' => $account['email'] ?? null,
+				'settingsUrl' => $this->urlGenerator->linkToRoute(
+					'settings.PersonalSettings.index',
+					['section' => Application::APP_ID],
+				),
+			],
+		);
+		$csp = new ContentSecurityPolicy();
+		$csp->addAllowedScriptDomain('blob:');
+		$csp->addAllowedWorkerSrcDomain('blob:');
+		$csp->allowEvalWasm();
+		$csp->allowEvalScript();
+		$response->setContentSecurityPolicy($csp);
+		return $response;
+	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -5,23 +5,41 @@ declare(strict_types=1);
 namespace OCA\Doom\Controller;
 
 use OCA\Doom\AppInfo\Application;
+use OCA\Doom\Service\JsDosAccountService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IRequest;
 
 /**
  * @psalm-suppress UnusedClass
  */
 class PageController extends Controller
 {
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private ?string $userId,
+        private JsDosAccountService $accountService,
+        private IInitialState $initialState,
+    ) {
+        parent::__construct($appName, $request);
+    }
+
     #[NoCSRFRequired]
     #[NoAdminRequired]
     #[OpenAPI(OpenAPI::SCOPE_IGNORE)]
     public function index(): TemplateResponse
     {
+        // Expose the stored account so it can be written to localStorage before
+        // js-dos boots (js-dos reads its account at script-eval time).
+        $account = $this->userId !== null ? $this->accountService->get($this->userId) : null;
+        $this->initialState->provideInitialState('account', $account);
+
         $response = new TemplateResponse(
             Application::APP_ID,
             'index',

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -43,6 +43,7 @@ class PageController extends Controller
         $response = new TemplateResponse(
             Application::APP_ID,
             'index',
+            ['email' => $account['email'] ?? null],
         );
         $csp = new ContentSecurityPolicy();
         $csp->addAllowedScriptDomain('blob:');

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Listener;
+
+use OCA\Doom\Service\JsDosAccountService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserDeletedEvent;
+
+/**
+ * @template-implements IEventListener<UserDeletedEvent>
+ */
+class UserDeletedListener implements IEventListener {
+	public function __construct(
+		private JsDosAccountService $accountService,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserDeletedEvent) {
+			return;
+		}
+
+		$this->accountService->delete($event->getUser()->getUID());
+	}
+}

--- a/lib/Service/JsDosAccountService.php
+++ b/lib/Service/JsDosAccountService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Service;
+
+use OCP\Security\ICredentialsManager;
+
+/**
+ * Stores the validated js-dos account (including the secret token) per user,
+ * encrypted at rest through {@see ICredentialsManager}.
+ */
+class JsDosAccountService {
+	private const CREDENTIALS_IDENTIFIER = 'doom_nextcloud_jsdos_account';
+
+	public function __construct(
+		private ICredentialsManager $credentialsManager,
+	) {
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function get(string $userId): ?array {
+		$value = $this->credentialsManager->retrieve($userId, self::CREDENTIALS_IDENTIFIER);
+
+		return is_array($value) ? $value : null;
+	}
+
+	/**
+	 * @param array<string, mixed> $account
+	 */
+	public function set(string $userId, array $account): void {
+		$this->credentialsManager->store($userId, self::CREDENTIALS_IDENTIFIER, $account);
+	}
+
+	public function delete(string $userId): void {
+		$this->credentialsManager->delete($userId, self::CREDENTIALS_IDENTIFIER);
+	}
+}

--- a/lib/Service/JsDosClient.php
+++ b/lib/Service/JsDosClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\Doom\Service;
 
 use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -21,12 +22,14 @@ class JsDosClient {
 
 	public function __construct(
 		private IClientService $clientService,
+		private LoggerInterface $logger,
 	) {
 	}
 
 	/**
 	 * @return array<string, mixed>|null the account, or null if the key is
 	 *                                   malformed or not tied to an account
+	 * @throws JsDosUnavailableException if the js-dos API cannot be reached
 	 */
 	public function resolveAccount(string $key): ?array {
 		if (!preg_match('/^[a-z]{5}$/', $key)) {
@@ -37,7 +40,8 @@ class JsDosClient {
 			$response = $this->clientService->newClient()->get(self::TOKEN_URL . $key);
 			$account = json_decode((string)$response->getBody(), true);
 		} catch (Throwable $e) {
-			return null;
+			$this->logger->error('Could not reach the js-dos API to validate a key', ['exception' => $e]);
+			throw new JsDosUnavailableException('js-dos API unreachable', 0, $e);
 		}
 
 		if (!is_array($account)

--- a/lib/Service/JsDosClient.php
+++ b/lib/Service/JsDosClient.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Service;
+
+use OCP\Http\Client\IClientService;
+use Throwable;
+
+/**
+ * Resolves a js-dos account from a key against the js-dos cloud API.
+ *
+ * The emulator itself cannot do this when self-hosted: its browser request to
+ * cloud.js-dos.com is blocked by CORS (the endpoint only allows the js-dos.com
+ * origins). Doing it server-side sidesteps that, and mirrors the emulator's own
+ * validation (5 lowercase letters, response must carry an email and a 5-char
+ * token).
+ */
+class JsDosClient {
+	private const TOKEN_URL = 'https://cloud.js-dos.com/token/get?id=';
+
+	public function __construct(
+		private IClientService $clientService,
+	) {
+	}
+
+	/**
+	 * @return array<string, mixed>|null the account, or null if the key is
+	 *                                   malformed or not tied to an account
+	 */
+	public function resolveAccount(string $key): ?array {
+		if (!preg_match('/^[a-z]{5}$/', $key)) {
+			return null;
+		}
+
+		try {
+			$response = $this->clientService->newClient()->get(self::TOKEN_URL . $key);
+			$account = json_decode((string)$response->getBody(), true);
+		} catch (Throwable $e) {
+			return null;
+		}
+
+		if (!is_array($account)
+			|| empty($account['email'])
+			|| !isset($account['token'])
+			|| !is_string($account['token'])
+			|| strlen($account['token']) !== 5
+		) {
+			return null;
+		}
+
+		unset($account['success']);
+
+		return $account;
+	}
+}

--- a/lib/Service/JsDosUnavailableException.php
+++ b/lib/Service/JsDosUnavailableException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Service;
+
+/**
+ * Thrown when the js-dos cloud API cannot be reached, as opposed to the API
+ * answering that a key is invalid.
+ */
+class JsDosUnavailableException extends \Exception {
+}

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Settings;
+
+use OCA\Doom\AppInfo\Application;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class PersonalSection implements IIconSection {
+	public function __construct(
+		private IL10N $l,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getID(): string {
+		return Application::APP_ID;
+	}
+
+	public function getName(): string {
+		return $this->l->t('Doom');
+	}
+
+	public function getPriority(): int {
+		return 80;
+	}
+
+	public function getIcon(): string {
+		return $this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg');
+	}
+}

--- a/lib/Settings/PersonalSettings.php
+++ b/lib/Settings/PersonalSettings.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Settings;
+
+use OCA\Doom\AppInfo\Application;
+use OCA\Doom\Service\JsDosAccountService;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Settings\ISettings;
+
+class PersonalSettings implements ISettings {
+	public function __construct(
+		private ?string $userId,
+		private JsDosAccountService $accountService,
+	) {
+	}
+
+	public function getForm(): TemplateResponse {
+		$account = $this->userId !== null ? $this->accountService->get($this->userId) : null;
+
+		return new TemplateResponse(Application::APP_ID, 'personal-settings', [
+			'email' => $account['email'] ?? null,
+		]);
+	}
+
+	public function getSection(): string {
+		return Application::APP_ID;
+	}
+
+	public function getPriority(): int {
+		return 50;
+	}
+}

--- a/templates/index.php
+++ b/templates/index.php
@@ -7,8 +7,32 @@ use OCP\Util;
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'inject-account');
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'js-dos');
 Util::addStyle(OCA\Doom\AppInfo\Application::APP_ID, 'js-dos');
+Util::addStyle(OCA\Doom\AppInfo\Application::APP_ID, 'doom');
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'load-game');
 
+/** @var \OCP\IL10N $l */
+/** @var array{email: ?string} $_ */
+$email = $_['email'] ?? null;
+$signedIn = is_string($email) && $email !== '';
 ?>
 
-<div id="doom" style="width: 100%;"></div>
+<div class="doom-wrapper">
+	<div id="doom-key-banner" role="note">
+		<span aria-hidden="true">&#128273;</span>
+		<span class="doom-key-banner-text">
+			<?php if ($signedIn): ?>
+				<?php p($l->t('Signed in to js-dos as %s.', [$email])); ?>
+				<a id="doom-key-banner-settings" href="#"><?php p($l->t('Manage key')); ?></a>
+			<?php else: ?>
+				<?php p($l->t('New: save your js-dos key once and stay signed in on all your devices.')); ?>
+				<a id="doom-key-banner-settings" href="#"><?php p($l->t('Set it up')); ?></a>
+			<?php endif; ?>
+		</span>
+		<button id="doom-key-banner-dismiss" type="button"
+				title="<?php p($l->t('Dismiss')); ?>" aria-label="<?php p($l->t('Dismiss')); ?>">
+			&times;
+		</button>
+	</div>
+
+	<div id="doom"></div>
+</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OCP\Util;
 
+Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'inject-account');
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'js-dos');
 Util::addStyle(OCA\Doom\AppInfo\Application::APP_ID, 'js-dos');
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'load-game');

--- a/templates/index.php
+++ b/templates/index.php
@@ -11,9 +11,10 @@ Util::addStyle(OCA\Doom\AppInfo\Application::APP_ID, 'doom');
 Util::addScript(OCA\Doom\AppInfo\Application::APP_ID, 'load-game');
 
 /** @var \OCP\IL10N $l */
-/** @var array{email: ?string} $_ */
+/** @var array{email: ?string, settingsUrl: string} $_ */
 $email = $_['email'] ?? null;
 $signedIn = is_string($email) && $email !== '';
+$settingsUrl = $_['settingsUrl'] ?? '';
 ?>
 
 <div class="doom-wrapper">
@@ -22,10 +23,10 @@ $signedIn = is_string($email) && $email !== '';
 		<span class="doom-key-banner-text">
 			<?php if ($signedIn): ?>
 				<?php p($l->t('Signed in to js-dos as %s.', [$email])); ?>
-				<a id="doom-key-banner-settings" href="#"><?php p($l->t('Manage key')); ?></a>
+				<a href="<?php p($settingsUrl); ?>"><?php p($l->t('Manage key')); ?></a>
 			<?php else: ?>
 				<?php p($l->t('New: save your js-dos key once and stay signed in on all your devices.')); ?>
-				<a id="doom-key-banner-settings" href="#"><?php p($l->t('Set it up')); ?></a>
+				<a href="<?php p($settingsUrl); ?>"><?php p($l->t('Set it up')); ?></a>
 			<?php endif; ?>
 		</span>
 		<button id="doom-key-banner-dismiss" type="button"

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use OCA\Doom\AppInfo\Application;
+use OCP\Util;
+
+Util::addScript(Application::APP_ID, 'personal-settings');
+
+/** @var \OCP\IL10N $l */
+/** @var array{email: ?string} $_ */
+$email = $_['email'] ?? null;
+?>
+
+<div id="doom-personal-settings" class="section">
+	<h2><?php p($l->t('Doom')); ?></h2>
+	<p class="settings-hint">
+		<?php p($l->t('Enter your js-dos key to stay signed in across browsers and devices. It is validated with js-dos and stored encrypted for your account.')); ?>
+	</p>
+	<div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+		<input id="doom-key-input" type="text" maxlength="5" autocomplete="off"
+			   autocapitalize="off" spellcheck="false" placeholder="abcde">
+		<button id="doom-key-save" class="primary" type="button"><?php p($l->t('Save')); ?></button>
+		<button id="doom-key-forget" type="button"><?php p($l->t('Remove')); ?></button>
+	</div>
+	<p id="doom-key-status" aria-live="polite" data-email="<?php p($email ?? ''); ?>"></p>
+</div>

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -6,10 +6,12 @@ use OCA\Doom\AppInfo\Application;
 use OCP\Util;
 
 Util::addScript(Application::APP_ID, 'personal-settings');
+Util::addStyle(Application::APP_ID, 'personal-settings');
 
 /** @var \OCP\IL10N $l */
 /** @var array{email: ?string} $_ */
 $email = $_['email'] ?? null;
+$signedIn = is_string($email) && $email !== '';
 ?>
 
 <div id="doom-personal-settings" class="section">
@@ -17,11 +19,30 @@ $email = $_['email'] ?? null;
 	<p class="settings-hint">
 		<?php p($l->t('Enter your js-dos key to stay signed in across browsers and devices. It is validated with js-dos and stored encrypted for your account.')); ?>
 	</p>
-	<div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-		<input id="doom-key-input" type="text" maxlength="5" autocomplete="off"
-			   autocapitalize="off" spellcheck="false" placeholder="abcde">
-		<button id="doom-key-save" class="primary" type="button"><?php p($l->t('Save')); ?></button>
-		<button id="doom-key-forget" type="button"><?php p($l->t('Remove')); ?></button>
+
+	<div id="doom-key-signed-in" data-email="<?php p($email ?? ''); ?>"
+		 style="<?php p($signedIn ? '' : 'display: none;'); ?>">
+		<p class="doom-key-identity">
+			<span aria-hidden="true" class="doom-key-check">&#10003;</span>
+			<span>
+				<?php p($l->t('Signed in as')); ?>
+				<strong id="doom-key-email"><?php p($email ?? ''); ?></strong>
+			</span>
+		</p>
+		<div class="doom-key-actions">
+			<button id="doom-key-change" type="button"><?php p($l->t('Use a different key')); ?></button>
+			<button id="doom-key-forget" type="button"><?php p($l->t('Remove key')); ?></button>
+		</div>
 	</div>
-	<p id="doom-key-status" aria-live="polite" data-email="<?php p($email ?? ''); ?>"></p>
+
+	<div id="doom-key-form" style="<?php p($signedIn ? 'display: none;' : ''); ?>">
+		<div class="doom-key-row">
+			<input id="doom-key-input" type="text" maxlength="5" autocomplete="off"
+				   autocapitalize="off" spellcheck="false" placeholder="abcde">
+			<button id="doom-key-save" class="primary" type="button"><?php p($l->t('Save')); ?></button>
+			<button id="doom-key-cancel" type="button" style="display: none;"><?php p($l->t('Cancel')); ?></button>
+		</div>
+	</div>
+
+	<p id="doom-key-status" aria-live="polite"></p>
 </div>

--- a/tests/php/Unit/Controller/ApiControllerTest.php
+++ b/tests/php/Unit/Controller/ApiControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Controller;
+
+use OCA\Doom\Controller\ApiController;
+use OCA\Doom\Service\JsDosAccountService;
+use OCA\Doom\Service\JsDosClient;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ApiControllerTest extends TestCase {
+	private const USER_ID = 'alice';
+
+	private IRequest&MockObject $request;
+	private JsDosAccountService&MockObject $accountService;
+	private JsDosClient&MockObject $jsDosClient;
+	private ApiController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(JsDosAccountService::class);
+		$this->jsDosClient = $this->createMock(JsDosClient::class);
+		$this->controller = new ApiController(
+			'doom_nextcloud',
+			$this->request,
+			self::USER_ID,
+			$this->accountService,
+			$this->jsDosClient,
+		);
+	}
+
+	public function testGetStateReturnsStoredAccount(): void {
+		$account = ['email' => 'a@b.c', 'token' => 'abcde'];
+		$this->accountService->method('get')->with(self::USER_ID)->willReturn($account);
+
+		$response = $this->controller->getState();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['account' => $account], $response->getData());
+	}
+
+	public function testSetKeyValidatesStoresAndReturnsAccount(): void {
+		$account = ['email' => 'a@b.c', 'token' => 'abcde', 'premium' => false];
+		$this->jsDosClient->method('resolveAccount')->with('abcde')->willReturn($account);
+		$this->accountService->expects($this->once())
+			->method('set')
+			->with(self::USER_ID, $account);
+
+		$response = $this->controller->setKey('abcde');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['account' => $account], $response->getData());
+	}
+
+	public function testSetKeyRejectsInvalidKey(): void {
+		$this->jsDosClient->method('resolveAccount')->with('nope')->willReturn(null);
+		$this->accountService->expects($this->never())->method('set');
+
+		$response = $this->controller->setKey('nope');
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+	}
+
+	public function testDeleteStateDeletes(): void {
+		$this->accountService->expects($this->once())
+			->method('delete')
+			->with(self::USER_ID);
+
+		$response = $this->controller->deleteState();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['status' => 'ok'], $response->getData());
+	}
+
+	public function testGetStateReturnsUnauthorizedWithoutUser(): void {
+		$controller = new ApiController('doom_nextcloud', $this->request, null, $this->accountService, $this->jsDosClient);
+		$this->accountService->expects($this->never())->method('get');
+
+		$response = $controller->getState();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+}

--- a/tests/php/Unit/Controller/ApiControllerTest.php
+++ b/tests/php/Unit/Controller/ApiControllerTest.php
@@ -7,6 +7,7 @@ namespace OCA\Doom\Tests\Unit\Controller;
 use OCA\Doom\Controller\ApiController;
 use OCA\Doom\Service\JsDosAccountService;
 use OCA\Doom\Service\JsDosClient;
+use OCA\Doom\Service\JsDosUnavailableException;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -34,16 +35,6 @@ class ApiControllerTest extends TestCase {
 		);
 	}
 
-	public function testGetStateReturnsStoredAccount(): void {
-		$account = ['email' => 'a@b.c', 'token' => 'abcde'];
-		$this->accountService->method('get')->with(self::USER_ID)->willReturn($account);
-
-		$response = $this->controller->getState();
-
-		$this->assertSame(Http::STATUS_OK, $response->getStatus());
-		$this->assertSame(['account' => $account], $response->getData());
-	}
-
 	public function testSetKeyValidatesStoresAndReturnsAccount(): void {
 		$account = ['email' => 'a@b.c', 'token' => 'abcde', 'premium' => false];
 		$this->jsDosClient->method('resolveAccount')->with('abcde')->willReturn($account);
@@ -66,6 +57,16 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
 	}
 
+	public function testSetKeyReturnsServiceUnavailableWhenJsDosUnreachable(): void {
+		$this->jsDosClient->method('resolveAccount')
+			->willThrowException(new JsDosUnavailableException());
+		$this->accountService->expects($this->never())->method('set');
+
+		$response = $this->controller->setKey('abcde');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+	}
+
 	public function testDeleteStateDeletes(): void {
 		$this->accountService->expects($this->once())
 			->method('delete')
@@ -77,11 +78,11 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame(['status' => 'ok'], $response->getData());
 	}
 
-	public function testGetStateReturnsUnauthorizedWithoutUser(): void {
+	public function testSetKeyReturnsUnauthorizedWithoutUser(): void {
 		$controller = new ApiController('doom_nextcloud', $this->request, null, $this->accountService, $this->jsDosClient);
-		$this->accountService->expects($this->never())->method('get');
+		$this->jsDosClient->expects($this->never())->method('resolveAccount');
 
-		$response = $controller->getState();
+		$response = $controller->setKey('abcde');
 
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}

--- a/tests/php/Unit/Controller/PageControllerTest.php
+++ b/tests/php/Unit/Controller/PageControllerTest.php
@@ -56,15 +56,35 @@ class PageControllerTest extends TestCase {
 		$this->assertSame(self::SETTINGS_URL, $response->getParams()['settingsUrl']);
 	}
 
-	public function testIndexProvidesNullWhenNoUser(): void {
+	public function testIndexProvidesEmptyAccountWhenNoUser(): void {
 		$this->accountService->expects($this->never())->method('get');
 		$this->initialState->expects($this->once())
 			->method('provideInitialState')
-			->with('account', null);
+			->with('account', []);
 		$controller = new PageController(
 			'doom_nextcloud',
 			$this->request,
 			null,
+			$this->accountService,
+			$this->initialState,
+			$this->urlGenerator,
+		);
+
+		$controller->index();
+	}
+
+	public function testIndexProvidesEmptyAccountWhenUserHasNoStoredAccount(): void {
+		$this->accountService->expects($this->once())
+			->method('get')
+			->with(self::USER_ID)
+			->willReturn(null);
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('account', []);
+		$controller = new PageController(
+			'doom_nextcloud',
+			$this->request,
+			self::USER_ID,
 			$this->accountService,
 			$this->initialState,
 			$this->urlGenerator,

--- a/tests/php/Unit/Controller/PageControllerTest.php
+++ b/tests/php/Unit/Controller/PageControllerTest.php
@@ -44,6 +44,7 @@ class PageControllerTest extends TestCase {
 
 		$this->assertInstanceOf(TemplateResponse::class, $response);
 		$this->assertSame('index', $response->getTemplateName());
+		$this->assertSame('a@b.c', $response->getParams()['email']);
 	}
 
 	public function testIndexProvidesNullWhenNoUser(): void {

--- a/tests/php/Unit/Controller/PageControllerTest.php
+++ b/tests/php/Unit/Controller/PageControllerTest.php
@@ -9,21 +9,28 @@ use OCA\Doom\Service\JsDosAccountService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PageControllerTest extends TestCase {
 	private const USER_ID = 'alice';
+	private const SETTINGS_URL = '/settings/user/doom_nextcloud';
 
 	private IRequest&MockObject $request;
 	private JsDosAccountService&MockObject $accountService;
 	private IInitialState&MockObject $initialState;
+	private IURLGenerator&MockObject $urlGenerator;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->request = $this->createMock(IRequest::class);
 		$this->accountService = $this->createMock(JsDosAccountService::class);
 		$this->initialState = $this->createMock(IInitialState::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->urlGenerator->method('linkToRoute')
+			->with('settings.PersonalSettings.index', ['section' => 'doom_nextcloud'])
+			->willReturn(self::SETTINGS_URL);
 	}
 
 	public function testIndexProvidesStoredAccountAsInitialState(): void {
@@ -38,6 +45,7 @@ class PageControllerTest extends TestCase {
 			self::USER_ID,
 			$this->accountService,
 			$this->initialState,
+			$this->urlGenerator,
 		);
 
 		$response = $controller->index();
@@ -45,6 +53,7 @@ class PageControllerTest extends TestCase {
 		$this->assertInstanceOf(TemplateResponse::class, $response);
 		$this->assertSame('index', $response->getTemplateName());
 		$this->assertSame('a@b.c', $response->getParams()['email']);
+		$this->assertSame(self::SETTINGS_URL, $response->getParams()['settingsUrl']);
 	}
 
 	public function testIndexProvidesNullWhenNoUser(): void {
@@ -58,6 +67,7 @@ class PageControllerTest extends TestCase {
 			null,
 			$this->accountService,
 			$this->initialState,
+			$this->urlGenerator,
 		);
 
 		$controller->index();

--- a/tests/php/Unit/Controller/PageControllerTest.php
+++ b/tests/php/Unit/Controller/PageControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Controller;
+
+use OCA\Doom\Controller\PageController;
+use OCA\Doom\Service\JsDosAccountService;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PageControllerTest extends TestCase {
+	private const USER_ID = 'alice';
+
+	private IRequest&MockObject $request;
+	private JsDosAccountService&MockObject $accountService;
+	private IInitialState&MockObject $initialState;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(JsDosAccountService::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+	}
+
+	public function testIndexProvidesStoredAccountAsInitialState(): void {
+		$account = ['email' => 'a@b.c', 'token' => 'abcde'];
+		$this->accountService->method('get')->with(self::USER_ID)->willReturn($account);
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('account', $account);
+		$controller = new PageController(
+			'doom_nextcloud',
+			$this->request,
+			self::USER_ID,
+			$this->accountService,
+			$this->initialState,
+		);
+
+		$response = $controller->index();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('index', $response->getTemplateName());
+	}
+
+	public function testIndexProvidesNullWhenNoUser(): void {
+		$this->accountService->expects($this->never())->method('get');
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('account', null);
+		$controller = new PageController(
+			'doom_nextcloud',
+			$this->request,
+			null,
+			$this->accountService,
+			$this->initialState,
+		);
+
+		$controller->index();
+	}
+}

--- a/tests/php/Unit/Listener/UserDeletedListenerTest.php
+++ b/tests/php/Unit/Listener/UserDeletedListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Listener;
+
+use OCA\Doom\Listener\UserDeletedListener;
+use OCA\Doom\Service\JsDosAccountService;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserDeletedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UserDeletedListenerTest extends TestCase {
+	private JsDosAccountService&MockObject $service;
+	private UserDeletedListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->service = $this->createMock(JsDosAccountService::class);
+		$this->listener = new UserDeletedListener($this->service);
+	}
+
+	public function testDeletesStateForDeletedUser(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->service->expects($this->once())
+			->method('delete')
+			->with('alice');
+
+		$this->listener->handle(new UserDeletedEvent($user));
+	}
+
+	public function testIgnoresUnrelatedEvent(): void {
+		$this->service->expects($this->never())->method('delete');
+
+		$this->listener->handle(new Event());
+	}
+}

--- a/tests/php/Unit/Service/JsDosAccountServiceTest.php
+++ b/tests/php/Unit/Service/JsDosAccountServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Service;
+
+use OCA\Doom\Service\JsDosAccountService;
+use OCP\Security\ICredentialsManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class JsDosAccountServiceTest extends TestCase {
+	private const IDENTIFIER = 'doom_nextcloud_jsdos_account';
+	private const USER_ID = 'alice';
+
+	private ICredentialsManager&MockObject $credentialsManager;
+	private JsDosAccountService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->credentialsManager = $this->createMock(ICredentialsManager::class);
+		$this->service = new JsDosAccountService($this->credentialsManager);
+	}
+
+	public function testGetReturnsNullWhenNothingStored(): void {
+		$this->credentialsManager->method('retrieve')
+			->with(self::USER_ID, self::IDENTIFIER)
+			->willReturn(null);
+
+		$this->assertNull($this->service->get(self::USER_ID));
+	}
+
+	public function testGetReturnsStoredAccount(): void {
+		$account = ['email' => 'a@b.c', 'token' => 'abcde', 'premium' => false];
+		$this->credentialsManager->method('retrieve')
+			->with(self::USER_ID, self::IDENTIFIER)
+			->willReturn($account);
+
+		$this->assertSame($account, $this->service->get(self::USER_ID));
+	}
+
+	public function testSetStoresAccount(): void {
+		$account = ['email' => 'a@b.c', 'token' => 'abcde'];
+		$this->credentialsManager->expects($this->once())
+			->method('store')
+			->with(self::USER_ID, self::IDENTIFIER, $account);
+
+		$this->service->set(self::USER_ID, $account);
+	}
+
+	public function testDeleteRemovesCredentials(): void {
+		$this->credentialsManager->expects($this->once())
+			->method('delete')
+			->with(self::USER_ID, self::IDENTIFIER);
+
+		$this->service->delete(self::USER_ID);
+	}
+}

--- a/tests/php/Unit/Service/JsDosClientTest.php
+++ b/tests/php/Unit/Service/JsDosClientTest.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace OCA\Doom\Tests\Unit\Service;
 
 use OCA\Doom\Service\JsDosClient;
+use OCA\Doom\Service\JsDosUnavailableException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class JsDosClientTest extends TestCase {
 	private IClientService&MockObject $clientService;
 	private IClient&MockObject $client;
+	private LoggerInterface&MockObject $logger;
 	private JsDosClient $jsDosClient;
 
 	protected function setUp(): void {
@@ -21,7 +24,8 @@ class JsDosClientTest extends TestCase {
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->client = $this->createMock(IClient::class);
 		$this->clientService->method('newClient')->willReturn($this->client);
-		$this->jsDosClient = new JsDosClient($this->clientService);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->jsDosClient = new JsDosClient($this->clientService, $this->logger);
 	}
 
 	private function response(string $body): IResponse&MockObject {
@@ -63,9 +67,11 @@ class JsDosClientTest extends TestCase {
 		$this->assertNull($this->jsDosClient->resolveAccount('abcde'));
 	}
 
-	public function testResolveAccountReturnsNullOnHttpError(): void {
+	public function testResolveAccountThrowsAndLogsOnHttpError(): void {
 		$this->client->method('get')->willThrowException(new \RuntimeException('network'));
+		$this->logger->expects($this->once())->method('error');
 
-		$this->assertNull($this->jsDosClient->resolveAccount('abcde'));
+		$this->expectException(JsDosUnavailableException::class);
+		$this->jsDosClient->resolveAccount('abcde');
 	}
 }

--- a/tests/php/Unit/Service/JsDosClientTest.php
+++ b/tests/php/Unit/Service/JsDosClientTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Service;
+
+use OCA\Doom\Service\JsDosClient;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class JsDosClientTest extends TestCase {
+	private IClientService&MockObject $clientService;
+	private IClient&MockObject $client;
+	private JsDosClient $jsDosClient;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->client = $this->createMock(IClient::class);
+		$this->clientService->method('newClient')->willReturn($this->client);
+		$this->jsDosClient = new JsDosClient($this->clientService);
+	}
+
+	private function response(string $body): IResponse&MockObject {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getBody')->willReturn($body);
+		return $response;
+	}
+
+	public function testResolveAccountReturnsAccountForValidKey(): void {
+		$this->client->expects($this->once())
+			->method('get')
+			->with('https://cloud.js-dos.com/token/get?id=abcde')
+			->willReturn($this->response('{"email":"a@b.c","token":"abcde","premium":false,"success":true}'));
+
+		$account = $this->jsDosClient->resolveAccount('abcde');
+
+		// The transport-only "success" flag is stripped from the stored account.
+		$this->assertSame(['email' => 'a@b.c', 'token' => 'abcde', 'premium' => false], $account);
+	}
+
+	public function testResolveAccountRejectsInvalidFormatWithoutHttpCall(): void {
+		$this->client->expects($this->never())->method('get');
+
+		$this->assertNull($this->jsDosClient->resolveAccount('ABCDE'));
+		$this->assertNull($this->jsDosClient->resolveAccount('abcd'));
+		$this->assertNull($this->jsDosClient->resolveAccount('abcdef'));
+		$this->assertNull($this->jsDosClient->resolveAccount('abcd1'));
+	}
+
+	public function testResolveAccountReturnsNullWhenNoEmail(): void {
+		$this->client->method('get')->willReturn($this->response('{}'));
+
+		$this->assertNull($this->jsDosClient->resolveAccount('abcde'));
+	}
+
+	public function testResolveAccountReturnsNullWhenTokenNotFiveChars(): void {
+		$this->client->method('get')->willReturn($this->response('{"email":"a@b.c","token":"toolong"}'));
+
+		$this->assertNull($this->jsDosClient->resolveAccount('abcde'));
+	}
+
+	public function testResolveAccountReturnsNullOnHttpError(): void {
+		$this->client->method('get')->willThrowException(new \RuntimeException('network'));
+
+		$this->assertNull($this->jsDosClient->resolveAccount('abcde'));
+	}
+}

--- a/tests/php/Unit/Settings/PersonalSectionTest.php
+++ b/tests/php/Unit/Settings/PersonalSectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Settings;
+
+use OCA\Doom\Settings\PersonalSection;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PersonalSectionTest extends TestCase {
+	private IL10N&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
+	private PersonalSection $section;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->section = new PersonalSection($this->l10n, $this->urlGenerator);
+	}
+
+	public function testGetId(): void {
+		$this->assertSame('doom_nextcloud', $this->section->getID());
+	}
+
+	public function testGetName(): void {
+		$this->assertSame('Doom', $this->section->getName());
+	}
+
+	public function testGetPriorityIsInt(): void {
+		$this->assertIsInt($this->section->getPriority());
+	}
+
+	public function testGetIconUsesAppIcon(): void {
+		$this->urlGenerator->method('imagePath')
+			->with('doom_nextcloud', 'app-dark.svg')
+			->willReturn('/apps/doom_nextcloud/img/app-dark.svg');
+
+		$this->assertSame('/apps/doom_nextcloud/img/app-dark.svg', $this->section->getIcon());
+	}
+}

--- a/tests/php/Unit/Settings/PersonalSettingsTest.php
+++ b/tests/php/Unit/Settings/PersonalSettingsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Doom\Tests\Unit\Settings;
+
+use OCA\Doom\Service\JsDosAccountService;
+use OCA\Doom\Settings\PersonalSettings;
+use OCP\AppFramework\Http\TemplateResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PersonalSettingsTest extends TestCase {
+	private const USER_ID = 'alice';
+
+	private JsDosAccountService&MockObject $accountService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->accountService = $this->createMock(JsDosAccountService::class);
+	}
+
+	public function testGetFormRendersPersonalTemplateWithStoredEmail(): void {
+		$this->accountService->method('get')
+			->with(self::USER_ID)
+			->willReturn(['email' => 'a@b.c', 'token' => 'abcde']);
+		$settings = new PersonalSettings(self::USER_ID, $this->accountService);
+
+		$form = $settings->getForm();
+
+		$this->assertInstanceOf(TemplateResponse::class, $form);
+		$this->assertSame('doom_nextcloud', $form->getApp());
+		$this->assertSame('personal-settings', $form->getTemplateName());
+		$this->assertSame('a@b.c', $form->getParams()['email']);
+	}
+
+	public function testGetFormWithoutAccountPassesNullEmail(): void {
+		$this->accountService->method('get')->with(self::USER_ID)->willReturn(null);
+		$settings = new PersonalSettings(self::USER_ID, $this->accountService);
+
+		$this->assertNull($settings->getForm()->getParams()['email']);
+	}
+
+	public function testSectionAndPriority(): void {
+		$settings = new PersonalSettings(self::USER_ID, $this->accountService);
+
+		$this->assertSame('doom_nextcloud', $settings->getSection());
+		$this->assertIsInt($settings->getPriority());
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Yves César Amorim de Azevedo
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+use OCP\App\IAppManager;
+use OCP\Server;
+
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
+
+require_once __DIR__ . '/../../../../lib/base.php';
+require_once __DIR__ . '/../../../../tests/autoload.php';
+
+\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
+\OC::$composerAutoloader->addPsr4('OCA\\Doom\\Tests\\', __DIR__, true);
+
+Server::get(IAppManager::class)->loadApp('doom_nextcloud');
+
+OC_Hook::clear();

--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+		 bootstrap="bootstrap.php"
+		 executionOrder="depends,defects"
+		 beStrictAboutOutputDuringTests="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
+		 colors="true"
+		 cacheDirectory="../../build/logs/.phpunit.cache"
+		 displayDetailsOnTestsThatTriggerWarnings="true"
+		 beStrictAboutCoverageMetadata="true">
+	<testsuites>
+		<testsuite name="unit">
+			<directory suffix="Test.php">Unit</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<report>
+			<clover outputFile="../../build/logs/clover.xml"/>
+			<html outputDirectory="../../build/logs/html-coverage" lowUpperBound="50" highLowerBound="90"/>
+		</report>
+	</coverage>
+	<source>
+		<include>
+			<directory suffix=".php">../../lib</directory>
+		</include>
+	</source>
+</phpunit>

--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -8,8 +8,7 @@
 		 failOnWarning="true"
 		 colors="true"
 		 cacheDirectory="../../build/logs/.phpunit.cache"
-		 displayDetailsOnTestsThatTriggerWarnings="true"
-		 beStrictAboutCoverageMetadata="true">
+		 displayDetailsOnTestsThatTriggerWarnings="true">
 	<testsuites>
 		<testsuite name="unit">
 			<directory suffix="Test.php">Unit</directory>


### PR DESCRIPTION
The js-dos key had to be re-entered in the emulator UI on every browser
and device, since js-dos keeps its session only in `localStorage`.

## What this PR does

### Persist the js-dos key per user
- New **Personal settings → Doom** section where the user enters their
  js-dos key once. The key is validated against the js-dos API and the
  resulting account (email + token) is stored **encrypted** (`ICrypto`)
  in the user's preferences.
- On the Doom page, the stored account is exposed via initial state and
  written to `localStorage` **before js-dos boots** (`inject-account.js`),
  so the emulator starts already signed in — on any browser or device.
- Endpoints: `PUT /jsdos-key` (validate + save) and
  `DELETE /jsdos-state` (remove). The stored state is also cleaned up
  when the user account is deleted (`UserDeletedListener`).

### Settings UX
- When a key is already saved, the settings show a signed-in view
  ("✓ Signed in as email") with **Use a different key** and
  **Remove key** actions — the key input is only revealed when needed,
  with a Cancel action to go back.

### Announcement on the Doom page
- A slim, dismissible banner explains the new capability and links
  straight to the app's personal settings. The text adapts when the
  user is already signed in, and dismissal is persisted in
  `localStorage`.

### Housekeeping
- Styles moved out of the PHP templates into `css/doom.css` and
  `css/personal-settings.css`, loaded via `Util::addStyle`.

## Testing

- PHPUnit suite added for the new code (services, controllers,
  settings, listener): **25 tests, 45 assertions, all passing**.
- Manually verified: saving a valid/invalid key, removing the key,
  staying signed in after reload and in a second browser, and banner
  dismissal.

---

Related issue: #20 